### PR TITLE
Corrected in-file usage information

### DIFF
--- a/resize-font
+++ b/resize-font
@@ -18,11 +18,10 @@
 # urxvt.font: xft:Inconsolata:pixelsize=12
 
 # And re-bind some keymappings (if you want, below are the defaults):
-# URxvt.resize-font.smaller: C-minus
-# URxvt.resize-font.bigger: C-plus
-# URxvt.resize-font.reset: C-equal
-# URxvt.resize-font.show: C-question
-#
+# URxvt.keysym.C-plus:     perl:resize-font:bigger
+# URxvt.keysym.C-minus:    perl:resize-font:smaller
+# URxvt.keysym.C-equal:    perl:resize-font:reset
+# URxvt.keysym.C-question: perl:resize-font:show
 
 my $default_font;
 

--- a/resize-font
+++ b/resize-font
@@ -17,6 +17,9 @@
 # Set your font in ~/.Xresources:
 # urxvt.font: xft:Inconsolata:pixelsize=12
 
+# Activate extension:
+# URxvt.perl-ext-common: ...,resize-font
+
 # And re-bind some keymappings (if you want, below are the defaults):
 # URxvt.keysym.C-plus:     perl:resize-font:bigger
 # URxvt.keysym.C-minus:    perl:resize-font:smaller


### PR DESCRIPTION
Old in-file description for keymap re-binding was incorrect and incompatible with resize-font extension.